### PR TITLE
Changed section to div and h4s to divs

### DIFF
--- a/media-accessibility-reqs/index.html
+++ b/media-accessibility-reqs/index.html
@@ -93,6 +93,11 @@ var respecConfig = {
 };
 		</script>
 		<style type="text/css">
+.requirement
+{
+    font-weight: bold;
+    margin-bottom: 0.5em;
+}
 .req-handle
 {
 	font-weight : bold;
@@ -339,67 +344,67 @@ var respecConfig = {
       support for descriptions. Descriptions can also provide text that can be
       indexed and searched. </p>
 				<p>Systems supporting described video that are not open descriptions must: </p>
-				<section class="indent">
-					<h4 id="DV-1"><strong class="req-handle">[DV-1]</strong> Provide an indication that descriptions are available, and
-          are active/non-active. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DV-2"><strong class="req-handle">[DV-2]</strong> Render descriptions in a time-synchronized manner, using
-          the media resource as the timebase master. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DV-3"><strong class="req-handle">[DV-3]</strong> Support multiple description tracks (e.g., discrete tracks
-          containing different levels of detail). </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DV-4"><strong class="req-handle">[DV-4]</strong> Support recordings of real human speech as a track of the
-          media resource, or as an external file. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DV-5"><strong class="req-handle">[DV-5]</strong> Allow the author to independently adjust the volumes of the
-          audio description and original soundtracks. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DV-6"><strong class="req-handle">[DV-6]</strong> Allow the user to independently adjust the volumes of the
+				<div class="indent">
+					<div class='requirement' id="DV-1"><strong class="req-handle">[DV-1]</strong> Provide an indication that descriptions are available, and
+          are active/non-active. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DV-2"><strong class="req-handle">[DV-2]</strong> Render descriptions in a time-synchronized manner, using
+          the media resource as the timebase master. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DV-3"><strong class="req-handle">[DV-3]</strong> Support multiple description tracks (e.g., discrete tracks
+          containing different levels of detail). </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DV-4"><strong class="req-handle">[DV-4]</strong> Support recordings of real human speech as a track of the
+          media resource, or as an external file. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DV-5"><strong class="req-handle">[DV-5]</strong> Allow the author to independently adjust the volumes of the
+          audio description and original soundtracks. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DV-6"><strong class="req-handle">[DV-6]</strong> Allow the user to independently adjust the volumes of the
           audio description and original soundtracks, with the user's settings
-          overriding the author's. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DV-7"><strong class="req-handle">[DV-7]</strong> Permit smooth changes in volume rather than stepped changes.
-          The degree and speed of volume change should be under user control. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DV-8"><strong class="req-handle">[DV-8]</strong> Allow the author to provide fade and pan controls to be accurately
-          synchronised with the original soundtrack. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DV-9"><strong class="req-handle">[DV-9]</strong> Allow the author to use a codec which is optimised for voice
-          only, rather than requiring the same codec as the original soundtrack. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DV-10"><strong class="req-handle">[DV-10]</strong> Allow the user to select from among different languages
+          overriding the author's. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DV-7"><strong class="req-handle">[DV-7]</strong> Permit smooth changes in volume rather than stepped changes.
+          The degree and speed of volume change should be under user control. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DV-8"><strong class="req-handle">[DV-8]</strong> Allow the author to provide fade and pan controls to be accurately
+          synchronised with the original soundtrack. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DV-9"><strong class="req-handle">[DV-9]</strong> Allow the author to use a codec which is optimised for voice
+          only, rather than requiring the same codec as the original soundtrack. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DV-10"><strong class="req-handle">[DV-10]</strong> Allow the user to select from among different languages
           of descriptions, if available, even if they are different from the
-          language of the main soundtrack. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DV-11"><strong class="req-handle">[DV-11]</strong> Support the simultaneous playback of both the described
+          language of the main soundtrack. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DV-11"><strong class="req-handle">[DV-11]</strong> Support the simultaneous playback of both the described
           and non-described audio tracks so that one may be directed at separate
-          outputs (e.g., a speaker and headphones). </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DV-12"><strong class="req-handle">[DV-12]</strong> Provide a means to prevent descriptions from carrying over
+          outputs (e.g., a speaker and headphones). </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DV-12"><strong class="req-handle">[DV-12]</strong> Provide a means to prevent descriptions from carrying over
           from one program or channel when the user switches to a different program
-          or channel. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DV-13"><strong class="req-handle">[DV-13]</strong> Allow the user to relocate the description track within
+          or channel. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DV-13"><strong class="req-handle">[DV-13]</strong> Allow the user to relocate the description track within
           the audio field, with the user setting overriding the author setting.
-          The setting should be re-adjustable as the media plays. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DV-14"><strong class="req-handle">[DV-14]</strong> Support metadata, such as copyright information, usage rights,
-          language, etc. </h4>
-				</section>
+          The setting should be re-adjustable as the media plays. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DV-14"><strong class="req-handle">[DV-14]</strong> Support metadata, such as copyright information, usage rights,
+          language, etc. </div>
+				</div>
 			</section>
 			<section>
 				<h3> Text video description </h3>
@@ -428,15 +433,15 @@ var respecConfig = {
         in the program-audio track. </li>
 				</ul>
 				<p>Systems supporting text video descriptions must: </p>
-				<section class="indent">
-					<h4 id="TVD-1"><strong class="req-handle">[TVD-1]</strong> Support presentation of text video descriptions through
+				<div class="indent">
+					<div class='requirement' id="TVD-1"><strong class="req-handle">[TVD-1]</strong> Support presentation of text video descriptions through
           a screen reader or braille device, with playback speed control and
-          voice control and synchronisation points with the video. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="TVD-2"><strong class="req-handle">[TVD-2]</strong> TVDs need to be provided in a format that contains the following
-          information:</h4>
-				</section>
+          voice control and synchronisation points with the video. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="TVD-2"><strong class="req-handle">[TVD-2]</strong> TVDs need to be provided in a format that contains the following
+          information:</div>
+				</div>
 				<ol class="list-in-req">
 					<li>start time, text per description cue (the duration is determined
               dynamically, though an end time could provide a cut point) </li>
@@ -445,21 +450,21 @@ var respecConfig = {
 					<li>accompanying metadata providing labeling for speakers, language,
               etc. </li>
 				</ol>
-				<section class="indent">
-					<h4 id="TVD-3"><strong class="req-handle">[TVD-3]</strong> Where possible, provide a text or separate audio track privately
-          to those that need it in a mixed-viewing situation, e.g., through headphones. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="TVD-4"><strong class="req-handle">[TVD-4]</strong> Where possible, provide options for authors and users to
+				<div class="indent">
+					<div class='requirement' id="TVD-3"><strong class="req-handle">[TVD-3]</strong> Where possible, provide a text or separate audio track privately
+          to those that need it in a mixed-viewing situation, e.g., through headphones. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="TVD-4"><strong class="req-handle">[TVD-4]</strong> Where possible, provide options for authors and users to
           deal with the overflow case: continue reading, stop reading, and pause
           the video. (One solution from a user's point of view may be to pause
           the video and finish reading the TVD, for example.) User preference
-          should override authored option. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="TVD-5"><strong class="req-handle">[TVD-5]</strong> Support the control over speech-synthesis playback speed,
-          volume and voice, and provide synchronisation points with the video. </h4>
-				</section>
+          should override authored option. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="TVD-5"><strong class="req-handle">[TVD-5]</strong> Support the control over speech-synthesis playback speed,
+          volume and voice, and provide synchronisation points with the video. </div>
+				</div>
 			</section>
 			<section>
 				<h3> Extended video descriptions </h3>
@@ -479,24 +484,24 @@ var respecConfig = {
       between cause and effect, point out what is important to look at, or explain
       moods that might otherwise be missed. </p>
 				<p>Systems supporting extended audio descriptions must: </p>
-				<section class="indent">
-					<h4 id="EVD-1"><strong class="req-handle">[EVD-1]</strong> Support detailed user control as specified in <a href="#TVD-4">[TVD-4]</a> for
-          extended video descriptions. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="EVD-2"><strong class="req-handle">[EVD-2]</strong> Support automatically pausing the video and main audio tracks
-          in order to play a lengthy description. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="EVD-3"><strong class="req-handle">[EVD-3]</strong> Support resuming playback of video and main audio tracks
-          when the description is finished. </h4>
+				<div class="indent">
+					<div class='requirement' id="EVD-1"><strong class="req-handle">[EVD-1]</strong> Support detailed user control as specified in <a href="#TVD-4">[TVD-4]</a> for
+          extended video descriptions. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="EVD-2"><strong class="req-handle">[EVD-2]</strong> Support automatically pausing the video and main audio tracks
+          in order to play a lengthy description. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="EVD-3"><strong class="req-handle">[EVD-3]</strong> Support resuming playback of video and main audio tracks
+          when the description is finished. </div>
 					<p>Because the user is the ultimate arbiter of the rate at which TTS
 					playback occurs, it is not feasible for an author to guarantee that any
 					texted audio description can be played within the natural pauses in
 					dialog or narration of the primary audio resource. Therefore, all texted
 					descriptions must be treated as extended text descriptions potentially
 					requiring the pausing and resumption of primary resource playback.</p>
-				</section>
+				</div>
 			</section>
 			<section>
 				<h3> Clean audio </h3>
@@ -513,22 +518,22 @@ var respecConfig = {
       frequency-dependent, and the user may have usable hearing in some bands
       yet none at all in others. </p>
 				<p>Systems supporting clean audio and multiple audio tracks must: </p>
-				<section class="indent">
-					<h4 id="CA-1"><strong class="req-handle">[CA-1]</strong> Support clean
+				<div class="indent">
+					<div class='requirement' id="CA-1"><strong class="req-handle">[CA-1]</strong> Support clean
 					audio as a separate, alternative audio track from other audio-based
-					alternative media resources, including the primary audio resource. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CA-2"><strong class="req-handle">[CA-2]</strong> Support the synchronisation of multitrack audio either within
-          the same file or from separate files - preferably both. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CA-3"><strong class="req-handle">[CA-3]</strong> Support separate volume control of the different audio tracks. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CA-4"><strong class="req-handle">[CA-4]</strong> Support pre-emphasis filters, pitch-shifting, and other audio-processing
-          algorithms. </h4>
-				</section>
+					alternative media resources, including the primary audio resource. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CA-2"><strong class="req-handle">[CA-2]</strong> Support the synchronisation of multitrack audio either within
+          the same file or from separate files - preferably both. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CA-3"><strong class="req-handle">[CA-3]</strong> Support separate volume control of the different audio tracks. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CA-4"><strong class="req-handle">[CA-4]</strong> Support pre-emphasis filters, pitch-shifting, and other audio-processing
+          algorithms. </div>
+				</div>
 			</section>
 			<section>
 				<h3> Content navigation by content structure </h3>
@@ -630,56 +635,56 @@ var respecConfig = {
 				<p>The user can navigate by semantic structure within the time-based media,
       such as by chapters or scenes, if present in the media (UAAG 2.0 2.11.7). </p>
 				<p>Systems supporting content navigation must: </p>
-				<section class="indent">
-					<h4 id="CN-1"><strong class="req-handle">[CN-1]</strong> Provide a means to structure media resources so that users
+				<div class="indent">
+					<div class='requirement' id="CN-1"><strong class="req-handle">[CN-1]</strong> Provide a means to structure media resources so that users
           can navigate them by semantic content structure, e.g., through adding
           a track to the video that contains navigation markers (in table-of-content
           style). This means must allow authors to identify ancillary content
           structures, which may be a hierarchical structure. Support keeping
-          all media representations synchronised when users navigate. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CN-2"><strong class="req-handle">[CN-2]</strong> The navigation track should provide for hierarchical structures
-          with titles for the sections. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CN-3"><strong class="req-handle">[CN-3]</strong> Support both global navigation by the larger structural elements
+          all media representations synchronised when users navigate. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CN-2"><strong class="req-handle">[CN-2]</strong> The navigation track should provide for hierarchical structures
+          with titles for the sections. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CN-3"><strong class="req-handle">[CN-3]</strong> Support both global navigation by the larger structural elements
           of a media work, and also the most localized atomic structures of that
           work, even though authors may not have marked-up all levels of navigational
-          granularity. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CN-4"><strong class="req-handle">[CN-4]</strong> Support third-party provided structural navigation markup. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CN-5"><strong class="req-handle">[CN-5]</strong> Keep all content representations in sync, so that moving
+          granularity. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CN-4"><strong class="req-handle">[CN-4]</strong> Support third-party provided structural navigation markup. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CN-5"><strong class="req-handle">[CN-5]</strong> Keep all content representations in sync, so that moving
           to any particular structural element in media content also moves to
           the corresponding point in all provided alternative media representations
           (captions, described video, transcripts, etc) associated with that
-          work. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CN-6"><strong class="req-handle">[CN-6]</strong> Support direct access to any structural element, possibly
-          through URIs. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CN-7"><strong class="req-handle">[CN-7]</strong> Support pausing primary content traversal to provide access
-          to such ancillary content in line. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CN-8"><strong class="req-handle">[CN-8]</strong> Support skipping of ancillary content in order to not interrupt
-          content flow. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CN-9"><strong class="req-handle">[CN-9]</strong> Support access to each ancillary content item, including
+          work. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CN-6"><strong class="req-handle">[CN-6]</strong> Support direct access to any structural element, possibly
+          through URIs. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CN-7"><strong class="req-handle">[CN-7]</strong> Support pausing primary content traversal to provide access
+          to such ancillary content in line. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CN-8"><strong class="req-handle">[CN-8]</strong> Support skipping of ancillary content in order to not interrupt
+          content flow. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CN-9"><strong class="req-handle">[CN-9]</strong> Support access to each ancillary content item, including
           with &quot;next&quot; and &quot;previous&quot; controls, apart from
-          accessing the primary content of the title. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CN-10"><strong class="req-handle">[CN-10]</strong> Support that in bilingual texts both the original and translated
+          accessing the primary content of the title. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CN-10"><strong class="req-handle">[CN-10]</strong> Support that in bilingual texts both the original and translated
           texts can appear on screen, with both the original and translated text
-          highlighted, line by line, in sync with the audio narration. </h4>
-				</section>
+          highlighted, line by line, in sync with the audio narration. </div>
+				</div>
 			</section>
 			<section>
 				<h3> Captioning </h3>
@@ -717,41 +722,41 @@ var respecConfig = {
       to search the caption text to locate a specific video or an exact point
       in a video. </p>
 				<p>Formats for captions, subtitles or foreign-language subtitles must: </p>
-				<section class="indent">
-					<h4 id="CC-1"><strong class="req-handle">[CC-1]</strong> Render text in a time-synchronized manner,
-          using the media resource as the timebase master. </h4>
+				<div class="indent">
+					<div class='requirement' id="CC-1"><strong class="req-handle">[CC-1]</strong> Render text in a time-synchronized manner,
+          using the media resource as the timebase master. </div>
 					<p class="note">Most of the time, the main audio track would be the best candidate
         for the timebase. Where a video without audio, but with a text track,
         is available, the video track becomes the timebase master. Also, there
         may be situations where an explicit timing track is available. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-2"><strong class="req-handle">[CC-2]</strong> Allow the author to specify erasures, i.e.,
-          times when no text is displayed on the screen (no text cues are active). </h4>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-2"><strong class="req-handle">[CC-2]</strong> Allow the author to specify erasures, i.e.,
+          times when no text is displayed on the screen (no text cues are active). </div>
 					<p class="note">This should be possible both within media resources and caption
       formats. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-3"><strong class="req-handle">[CC-3]</strong> Allow the author to assign timestamps so
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-3"><strong class="req-handle">[CC-3]</strong> Allow the author to assign timestamps so
           that one caption/subtitle follows another, with no perceivable gap
-          in between. </h4>
+          in between. </div>
 					<p class="note">This means that caption cues should be able to either let the
         start time of the subsequent cue be determined by the duration of the
         cue or have the end time be implied by the start of the next cue. For
         overlapping captions, explicit start and end times are then required. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-4"><strong class="req-handle">[CC-4]</strong> Be available in a text encoding. </h4>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-4"><strong class="req-handle">[CC-4]</strong> Be available in a text encoding. </div>
 					<p class="note">This means that determined character encodings should be supported
         - which could be either by making the character encoding explicit or
         by enforcing a single default one such as UTF-8. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-5"><strong class="req-handle">[CC-5]</strong> Support positioning in all parts of the
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-5"><strong class="req-handle">[CC-5]</strong> Support positioning in all parts of the
           screen - either inside the media viewport but also possibly in a determined
           space next to the media viewport. This is particularly important when
           multiple captions are on screen at the same time and relate to different
-          speakers, or when in-picture text is avoided. </h4>
+          speakers, or when in-picture text is avoided. </div>
 					<p class="note">The minimum requirement is a bounding box (with an optional background)
         into which text is flowed, and that probably needs to be pixel aligned.
         The absolute position of text within the bounding box is less critical,
@@ -764,49 +769,49 @@ var respecConfig = {
         able to make that box larger and scale the text relatively, too. The
         positions inside the box should probably be into regions, such as top,
         right, bottom, left, center. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-6"><strong class="req-handle">[CC-6]</strong> Support the display of multiple regions
-          of text simultaneously. </h4>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-6"><strong class="req-handle">[CC-6]</strong> Support the display of multiple regions
+          of text simultaneously. </div>
 					<p class="note">This typically relates to multiple text cues that are defined
         on overlapping times. If the cues' rendering target are made out to different
         spatial regions, they can be displayed simultaneously. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-7"><strong class="req-handle">[CC-7]</strong> Display multiple rows of text when rendered
-          as text in a right-to-left or left-to-right language. </h4>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-7"><strong class="req-handle">[CC-7]</strong> Display multiple rows of text when rendered
+          as text in a right-to-left or left-to-right language. </div>
 					<p class="note">Internationalization is important not just for subtitles, as captions
       can be used in all languages. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-8"><strong class="req-handle">[CC-8]</strong> Allow the author to specify line breaks. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CC-9"><strong class="req-handle">[CC-9]</strong> Permit a range of font faces and sizes. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CC-10"><strong class="req-handle">[CC-10]</strong> Render a background in a range of colors,
-          supporting a full range of opacities. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CC-11"><strong class="req-handle">[CC-11]</strong> Render text in a range of colors. </h4>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-8"><strong class="req-handle">[CC-8]</strong> Allow the author to specify line breaks. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-9"><strong class="req-handle">[CC-9]</strong> Permit a range of font faces and sizes. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-10"><strong class="req-handle">[CC-10]</strong> Render a background in a range of colors,
+          supporting a full range of opacities. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-11"><strong class="req-handle">[CC-11]</strong> Render text in a range of colors. </div>
 					<p class="note">The user should have final control over rendering styles like
       color and fonts; e.g., through user preferences. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-12"><strong class="req-handle">[CC-12]</strong> Enable rendering of text with a thicker
-          outline or a drop shadow to allow for better contrast with the background. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CC-13"><strong class="req-handle">[CC-13]</strong> Where a background is used, it is preferable
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-12"><strong class="req-handle">[CC-12]</strong> Enable rendering of text with a thicker
+          outline or a drop shadow to allow for better contrast with the background. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-13"><strong class="req-handle">[CC-13]</strong> Where a background is used, it is preferable
           to keep the caption background visible even in times where no text
           is displayed, such that it minimises distraction. However, where captions
           are infrequent the background should be allowed to disappear to enable
-          the user to see as much of the underlying video as possible. </h4>
+          the user to see as much of the underlying video as possible. </div>
 					<p class="note">It may be technically possible to have cues without text. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-14"><strong class="req-handle">[CC-14]</strong> Allow the use of mixed display styles—
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-14"><strong class="req-handle">[CC-14]</strong> Allow the use of mixed display styles—
           e.g., mixing paint-on captions with pop-on captions— within a single
           caption cue or in the caption stream as a whole. Pop-on captions are
           usually one or two lines of captions that appear on screen and remain
@@ -818,90 +823,90 @@ var respecConfig = {
           and are used to indicate different speaker identifications. Each sentence &quot;rolls
           up&quot; to about three lines. The top line of the three disappears
           as a new bottom line is added, allowing the continuous rolling up of
-          new lines of captions. </h4>
+          new lines of captions. </div>
 					<p class="note">Similarly, in karaoke, individual characters are often &quot;painted
       on&quot;. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-15"><strong class="req-handle">[CC-15]</strong> Support positioning such that the lowest
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-15"><strong class="req-handle">[CC-15]</strong> Support positioning such that the lowest
           line of captions appears at least 1/12 of the total screen height above
           the bottom of the screen, when rendered as text in a right-to-left
-          or left-to-right language. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CC-16"><strong class="req-handle">[CC-16]</strong> Use conventions that include inserting
+          or left-to-right language. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-16"><strong class="req-handle">[CC-16]</strong> Use conventions that include inserting
           left-to-right and right-to-left segments within a vertical run (e.g.
           Tate-chu-yoko in Japanese), when rendered as text in a top-to-bottom
-          oriented language. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CC-17"><strong class="req-handle">[CC-17]</strong> Represent content of different natural
+          oriented language. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-17"><strong class="req-handle">[CC-17]</strong> Represent content of different natural
           languages. In some cases the inclusion of a few foreign words form
           part of the original soundtrack, and thus need to be in the same caption
           resource. Also allow for separate caption files for different languages
           and on-the-fly switching between them. This is also a requirement for
-          subtitles. </h4>
+          subtitles. </div>
 					<p class="note">Caption/subtitle files that are alternatives in different languages
         are probably best provided in different caption resources and are user
         selectable. Realistically, having no more than 2 languages present at
         the same time on screen is probably the limit. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-18"><strong class="req-handle">[CC-18]</strong> Represent content of at least those specific
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-18"><strong class="req-handle">[CC-18]</strong> Represent content of at least those specific
           natural languages that may be represented with [Unicode 3.2], including
           common typographical conventions of that language (e.g., through the
-          use of furigana and other forms of ruby text). </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CC-19"><strong class="req-handle">[CC-19]</strong> Present the full range of typographical
+          use of furigana and other forms of ruby text). </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-19"><strong class="req-handle">[CC-19]</strong> Present the full range of typographical
           glyphs, layout and punctuation marks normally associated with the natural
-          language's print-writing system. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CC-20"><strong class="req-handle">[CC-20]</strong> Permit in-line mark-up for foreign words
-          or phrases. </h4>
+          language's print-writing system. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-20"><strong class="req-handle">[CC-20]</strong> Permit in-line mark-up for foreign words
+          or phrases. </div>
 					<p class="note">Italics markup may be sufficient for a human user, but it is important
         to be able to mark up languages so that the text can be rendered correctly,
         since the same Unicode can be shared between languages and rendered differently
         in different contexts. This is mainly an localization issue. It is also important
         for audio rendering, to get correct pronunciation. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-21"><strong class="req-handle">[CC-21]</strong> Permit the distinction between different
-          speakers. </h4>
-				</section>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-21"><strong class="req-handle">[CC-21]</strong> Permit the distinction between different
+          speakers. </div>
+				</div>
 				<p>Further, systems that support captions must: </p>
-				<section class="indent">
-					<h4 id="CC-22"><strong class="req-handle">[CC-22]</strong> Support captions that are provided inside
-          media resources as tracks, or in external files. </h4>
+				<div class="indent">
+					<div class='requirement' id="CC-22"><strong class="req-handle">[CC-22]</strong> Support captions that are provided inside
+          media resources as tracks, or in external files. </div>
 					<p class="note">It is desirable to expose the same API to both. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-23"><strong class="req-handle">[CC-23]</strong> Ascertain that captions are displayed in
-          sync with the media resource. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CC-24"><strong class="req-handle">[CC-24]</strong> Support user activation/deactivation of
-          caption tracks. </h4>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-23"><strong class="req-handle">[CC-23]</strong> Ascertain that captions are displayed in
+          sync with the media resource. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-24"><strong class="req-handle">[CC-24]</strong> Support user activation/deactivation of
+          caption tracks. </div>
 					<p class="note">This requires a menu of some sort that displays the available
       tracks for activation/deactivation. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-25"><strong class="req-handle">[CC-25]</strong> Support edited and verbatim captions, if
-          available. </h4>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-25"><strong class="req-handle">[CC-25]</strong> Support edited and verbatim captions, if
+          available. </div>
 					<p class="note">Edited and verbatim captions can be provided in two different
         caption resources. There is a need to expose to the user how they differ,
         similar to how there can be caption tracks in different languages. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-26"><strong class="req-handle">[CC-26]</strong> Support multiple tracks of foreign-language
-          subtitles in different languages. </h4>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-26"><strong class="req-handle">[CC-26]</strong> Support multiple tracks of foreign-language
+          subtitles in different languages. </div>
 					<p class="note">These different-language &quot;tracks&quot; can be provided in
       different resources. </p>
-				</section>
-				<section class="indent">
-					<h4 id="CC-27"><strong class="req-handle">[CC-27]</strong> Support live-captioning functionality. </h4>
-				</section>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CC-27"><strong class="req-handle">[CC-27]</strong> Support live-captioning functionality. </div>
+				</div>
 			</section>
 			<section>
 				<h3> Enhanced captions/subtitles </h3>
@@ -924,51 +929,51 @@ var respecConfig = {
       a person, a strange term that needs a link to a definition, or
       an idiom that needs comments to explain it to a foreign-language speaker. </p>
 				<p>Systems that support enhanced captions must: </p>
-				<section class="indent">
-					<h4 id="ECC-1"><strong class="req-handle">[ECC-1]</strong> Support metadata markup for (sections of)
-          timed text cues. </h4>
+				<div class="indent">
+					<div class='requirement' id="ECC-1"><strong class="req-handle">[ECC-1]</strong> Support metadata markup for (sections of)
+          timed text cues. </div>
 					<p class="note">Such &quot;metadata&quot; markup can be realised through a @title
         attribute on a &lt;span&gt; of the text, or a hyperlink to another location
         where a term is explained, an &lt;abbr&gt; element, an   &lt;acronym&gt; element,
         a &lt;dfn&gt; element, or through RDFa or microdata. </p>
-				</section>
-				<section class="indent">
-					<h4 id="ECC-2"><strong class="req-handle">[ECC-2]</strong> Support hyperlinks and other activation
-          mechanisms for supplementary data for (sections of) caption text. </h4>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="ECC-2"><strong class="req-handle">[ECC-2]</strong> Support hyperlinks and other activation
+          mechanisms for supplementary data for (sections of) caption text. </div>
 					<p class="note">This can be realised through inclusion of links or
         buttons into timed text cues, where additional overlays could be created
         or a different page be loaded. One needs to deal here with the need to
         pause the media timeline for reading of the additional information. </p>
-				</section>
-				<section class="indent">
-					<h4 id="ECC-3"><strong class="req-handle">[ECC-3]</strong> Support text cues that may be longer than
+				</div>
+				<div class="indent">
+					<div class='requirement' id="ECC-3"><strong class="req-handle">[ECC-3]</strong> Support text cues that may be longer than
           the time available until the next text cue and thus provide overlapping
           text cues - in this case, a feature should be provided to decide if
           overlap is ok or should be cut or the media resource be paused while
           the caption is displayed. Timing would be provided by the author, but
-          with the user being able to override it. </h4>
+          with the user being able to override it. </div>
 					<p class="note">This feature is analogous to extended video descriptions - where
         timing for a text cue is longer than the available time for the cue,
         it may be necessary to halt the media to allow for more time to read
         back on the text and its additional material. In this case, the pause
         is dependent on the user's reading speed, so this may imply user control
         or timeouts. </p>
-				</section>
-				<section class="indent">
-					<h4 id="ECC-4"><strong class="req-handle">[ECC-4]</strong> It needs to be possible to define timed
+				</div>
+				<div class="indent">
+					<div class='requirement' id="ECC-4"><strong class="req-handle">[ECC-4]</strong> It needs to be possible to define timed
           text cues that are allowed to overlap with each other in time and be
           present on screen at the same time (e.g., those that come from speech
           of different speakers), and such that are not allowed to overlap and
           thus cause media playback pause to allow users to catch up with their
-          reading. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="ECC-5"><strong class="req-handle">[ECC-5]</strong> Allow users to define the reading speed
+          reading. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="ECC-5"><strong class="req-handle">[ECC-5]</strong> Allow users to define the reading speed
           and thus define how long each text cue requires, and whether media
-          playback needs to pause sometimes to let them catch up on their reading. </h4>
+          playback needs to pause sometimes to let them catch up on their reading. </div>
 					<p class="note">This can be a setting in the UA, which will define user-interface
       behavior. </p>
-				</section>
+				</div>
 			</section>
 			<section>
 				<h3> Sign translation </h3>
@@ -996,30 +1001,30 @@ var respecConfig = {
 				<p>Selecting from multiple tracks for different sign languages should be
       achieved in the same fashion that multiple caption/subtitle files are handled. </p>
 				<p>Systems supporting sign language must: </p>
-				<section class="indent">
-					<h4 id="SL-1"><strong class="req-handle">[SL-1]</strong> Support sign-language video either as a track as part of
-          a media resource or as an external file. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="SL-2"><strong class="req-handle">[SL-2]</strong> Support the synchronized playback of the sign-language video
-          with the media resource. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="SL-3"><strong class="req-handle">[SL-3]</strong> Support the display of sign-language video either as picture-in-picture
+				<div class="indent">
+					<div class='requirement' id="SL-1"><strong class="req-handle">[SL-1]</strong> Support sign-language video either as a track as part of
+          a media resource or as an external file. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="SL-2"><strong class="req-handle">[SL-2]</strong> Support the synchronized playback of the sign-language video
+          with the media resource. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="SL-3"><strong class="req-handle">[SL-3]</strong> Support the display of sign-language video either as picture-in-picture
           or alpha-blended overlay, as parallel video, or as the main video with
           the original video as picture-in-picture or alpha-blended overlay.
           Parallel video here means two discrete videos playing in sync with
           each other. It is preferable to have one discrete   &lt;video&gt; element
           contain all pieces for sync purposes rather than specifying multiple &lt;video&gt; elements
-          intended to work in sync. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="SL-4"><strong class="req-handle">[SL-4]</strong> Support multiple sign-language tracks in several sign languages. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="SL-5"><strong class="req-handle">[SL-5]</strong> Support the interactive activation/deactivation of a sign-language
-          track by the user. </h4>
-				</section>
+          intended to work in sync. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="SL-4"><strong class="req-handle">[SL-4]</strong> Support multiple sign-language tracks in several sign languages. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="SL-5"><strong class="req-handle">[SL-5]</strong> Support the interactive activation/deactivation of a sign-language
+          track by the user. </div>
+				</div>
 			</section>
 			<section>
 				<h3> Transcripts </h3>
@@ -1037,16 +1042,16 @@ var respecConfig = {
       the caption and video description, so that it is a complete representation
       of the material, as well as containing any interactive options. </p>
 				<p>Systems supporting transcripts must: </p>
-				<section class="indent">
-					<h4 id="T-1"><strong class="req-handle">[T-1]</strong> Support the provisioning of a full text transcript for the
+				<div class="indent">
+					<div class='requirement' id="T-1"><strong class="req-handle">[T-1]</strong> Support the provisioning of a full text transcript for the
           media asset in a separate but linked resource, where the linkage is
-          programatically accessible to AT. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="T-2"><strong class="req-handle">[T-2]</strong> Support the provisioning of both scrolling and static display
+          programatically accessible to AT. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="T-2"><strong class="req-handle">[T-2]</strong> Support the provisioning of both scrolling and static display
           of a full text transcript with the media resource, e.g., in a area next
-          to the video or underneath the video, which is also AT accessible. </h4>
-				</section>
+          to the video or underneath the video, which is also AT accessible. </div>
+				</div>
 			</section>
 		</section>
 		<section>
@@ -1064,20 +1069,20 @@ var respecConfig = {
 				<p>It is imperative that controls be device independent, so that control
       may be achieved by keyboard, pointing device, speech, etc. </p>
 				<p>Systems supporting accessibility for interactive controls must: </p>
-				<section class="indent">
-					<h4 id="IC-1"><strong class="req-handle">[IC-1]</strong> Support operation of all functionality via
+				<div class="indent">
+					<div class='requirement' id="IC-1"><strong class="req-handle">[IC-1]</strong> Support operation of all functionality via
           the keyboard on systems where a keyboard is (or can be) present, and
           where <a href="http://www.w3.org/TR/UAAG20/#def-focusable-element">focusable elements</a>
 					are used for interaction. This does not forbid and should not discourage providing mouse
 					input or other input methods in addition to keyboard operation.
-					(UAAG 2.0 2.1.1) </h4>
+					(UAAG 2.0 2.1.1) </div>
 					<p class="note">This means that all interaction possibilities with media elements
         need to be keyboard accessible; e.g., through being able to tab onto
         the play, pause, mute buttons, and to move the playback position from
         the keyboard. </p>
-				</section>
-				<section class="indent">
-					<h4 id="IC-2"><strong class="req-handle">[IC-2]</strong> Support a rich set of native controls for
+				</div>
+				<div class="indent">
+					<div class='requirement' id="IC-2"><strong class="req-handle">[IC-2]</strong> Support a rich set of native controls for
           media operation, including but not limited to play, pause, stop, jump
           to beginning, jump to end, scale player size (up to full screen), adjust
           volume, mute, captions on/off, descriptions on/off, selection of audio
@@ -1085,48 +1090,48 @@ var respecConfig = {
           language, location of captions, size of captions, video contrast/brightness,
           playback rate, content navigation on same level (next/prev) and between
           levels (up/down) etc. This is also a particularly important requirement
-          on mobile devices or devices without a keyboard. </h4>
+          on mobile devices or devices without a keyboard. </div>
 					<p class="note">This means that the @controls content attribute needs to provide
         an extended set of control functionality including functionality for
         accessibility users. </p>
-				</section>
-				<section class="indent">
-					<h4 id="IC-3"><strong class="req-handle">[IC-3]</strong> All functionality available to native controls
+				</div>
+				<div class="indent">
+					<div class='requirement' id="IC-3"><strong class="req-handle">[IC-3]</strong> All functionality available to native controls
           must also be available to scripted controls. The author would be able
-          to choose any/all of the controls, skin them and position them. </h4>
+          to choose any/all of the controls, skin them and position them. </div>
 					<p class="note">This means that new IDL attributes need to be added to the media
       elements for the extra controls that are accessibility related. </p>
-				</section>
-				<section class="indent">
-					<h4 id="IC-4"><strong class="req-handle">[IC-4]</strong> It must always be possible to enable native
+				</div>
+				<div class="indent">
+					<div class='requirement' id="IC-4"><strong class="req-handle">[IC-4]</strong> It must always be possible to enable native
           controls regardless of the author preference to guarantee that such
           functionality is available and essentially override author settings
           through user control. This is also a particularly important requirement
-          on mobile devices or devices without a keyboard. </h4>
+          on mobile devices or devices without a keyboard. </div>
 					<p class="note">This could be enabled through a context menu, which is keyboard
       accessible and its keyboard access cannot be turned off. </p>
-				</section>
-				<section class="indent">
-					<h4 id="IC-5"><strong class="req-handle">[IC-5]</strong> The scripted and native controls must go
+				</div>
+				<div class="indent">
+					<div class='requirement' id="IC-5"><strong class="req-handle">[IC-5]</strong> The scripted and native controls must go
           through the same platform-level accessibility framework (where it exists),
           so that a user presented with the scripted version is not shut out
-          from some expected behaviour. </h4>
+          from some expected behaviour. </div>
 					<p class="note">This is below the level of HTML and means that the accessibility
       platform needs to be extended to allow access to these controls. </p>
-				</section>
-				<section class="indent">
-					<h4 id="IC-6"><strong class="req-handle">[IC-6]</strong> Autoplay on media elements is a particularly
+				</div>
+				<div class="indent">
+					<div class='requirement' id="IC-6"><strong class="req-handle">[IC-6]</strong> Autoplay on media elements is a particularly
           difficult issue to manage for vision-impaired users, since the mouse
           allows other users to an auto-playing element on a page with a single
           interaction. Therefore, autoplay state needs to be exposed to the platform-level
           accessibility framework. The vision-impaired user must be able to stop
           autoplay either generally on all media elements through a setting,
-          or for particular pages through a single keyboard user interaction. </h4>
+          or for particular pages through a single keyboard user interaction. </div>
 					<p class="note">This could be enabled through encouraging publishers to use @autoplay,
         encouraging UAs to implement accessibility settings that allow to turn
         off all autoplay, and encouraging <abbr title="Assistive Technology">AT</abbr> to implement a shortcut key to stop
         all autoplay on a web page. </p>
-				</section>
+				</div>
 			</section>
 			<section>
 				<h3> Granularity level control for structural navigation </h3>
@@ -1134,25 +1139,25 @@ var respecConfig = {
       mechanism must be provided for adjusting the granularity of the specific
       structural navigation point next and previous. Users must be able to set
       the range/scope of next and previous in real time. </p>
-				<section class="indent">
-					<h4 id="CNS-1"><strong class="req-handle">[CNS-1]</strong> All identified structures, including ancillary content as
+				<div class="indent">
+					<div class='requirement' id="CNS-1"><strong class="req-handle">[CNS-1]</strong> All identified structures, including ancillary content as
           defined in &quot;Content Navigation&quot; above, must be accessible
           with the use of &quot;next&quot; and &quot;previous,&quot; as refined
-          by the granularity control. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CNS-2"><strong class="req-handle">[CNS-2]</strong> Users must be able to discover, skip, play-in-line, or directly
-          access ancillary content structures. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CNS-3"><strong class="req-handle">[CNS-3]</strong> Users need to be able to access the granularity control
-          using any input mode, e.g., keyboard, speech, pointer, etc. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="CNS-4"><strong class="req-handle">[CNS-4]</strong> Producers and authors may optionally provide additional
+          by the granularity control. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CNS-2"><strong class="req-handle">[CNS-2]</strong> Users must be able to discover, skip, play-in-line, or directly
+          access ancillary content structures. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CNS-3"><strong class="req-handle">[CNS-3]</strong> Users need to be able to access the granularity control
+          using any input mode, e.g., keyboard, speech, pointer, etc. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="CNS-4"><strong class="req-handle">[CNS-4]</strong> Producers and authors may optionally provide additional
           access options to identified structures, such as direct access to any
-          node in a table of contents. </h4>
-				</section>
+          node in a table of contents. </div>
+				</div>
 			</section>
 			<section>
 				<h3> Time-scale modification </h3>
@@ -1163,27 +1168,27 @@ var respecConfig = {
       on many devices, especially audiobook players, for some 20 years now. </p>
 				<p>The user can adjust the playback rate of prerecorded time-based media
         content, such that all of the following are true (UAAG 2.0 2.11.4): </p>
-				<section class="indent">
-					<h4 id="TSM-1"><strong class="req-handle">[TSM-1]</strong> The user can adjust the playback rate of the time-based
-          media tracks to between 50% and 250% of real time. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="TSM-2"><strong class="req-handle">[TSM-2]</strong> Speech whose playback rate has been adjusted by the user
-          maintains pitch in order to limit degradation of the speech quality. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="TSM-3"><strong class="req-handle">[TSM-3]</strong> All provided alternative media tracks remain synchronized
-          across this required range of playback rates. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="TSM-4"><strong class="req-handle">[TSM-4]</strong> The user agent provides a function that resets the playback
-          rate to normal (100%). </h4>
-				</section>
-				<section class="indent">
-					<h4 id="TSM-5"><strong class="req-handle">[TSM-5]</strong> The user can stop, pause, and resume rendered audio and
+				<div class="indent">
+					<div class='requirement' id="TSM-1"><strong class="req-handle">[TSM-1]</strong> The user can adjust the playback rate of the time-based
+          media tracks to between 50% and 250% of real time. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="TSM-2"><strong class="req-handle">[TSM-2]</strong> Speech whose playback rate has been adjusted by the user
+          maintains pitch in order to limit degradation of the speech quality. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="TSM-3"><strong class="req-handle">[TSM-3]</strong> All provided alternative media tracks remain synchronized
+          across this required range of playback rates. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="TSM-4"><strong class="req-handle">[TSM-4]</strong> The user agent provides a function that resets the playback
+          rate to normal (100%). </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="TSM-5"><strong class="req-handle">[TSM-5]</strong> The user can stop, pause, and resume rendered audio and
           animation content (including video and animated images) that last three
-          or more seconds at their default playback rate. (UAAG 2.0 2.11.5) </h4>
-				</section>
+          or more seconds at their default playback rate. (UAAG 2.0 2.11.5) </div>
+				</div>
 			</section>
 			<section>
 				<h3> Production practice and resulting requirements </h3>
@@ -1219,36 +1224,36 @@ var respecConfig = {
       common time-stamp format must be declared in HTML5, so that authoring tools
       can conform to a required output. </p>
 				<p>Systems supporting accessibility needs for media must: </p>
-				<section class="indent">
-					<h4 id="PP-1"><strong class="req-handle">[PP-1]</strong> Support existing production practice for alternative content
+				<div class="indent">
+					<div class='requirement' id="PP-1"><strong class="req-handle">[PP-1]</strong> Support existing production practice for alternative content
           resources, in particular allow for the association of separate alternative
           content resources to media resources. Browsers cannot support all forms
           of time-stamp formats out there, just as they cannot support all forms
           of image formats (etc.). This necessitates a clear and unambiguous
           declared format, so that existing authoring tools can be configured
-          to export finished files in the required format. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="PP-2"><strong class="req-handle">[PP-2]</strong> Support the association of authoring and rights metadata
-          with alternative content resources, including copyright and usage information. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="PP-3"><strong class="req-handle">[PP-3]</strong> Support the simple replacement of alternative content resources
+          to export finished files in the required format. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="PP-2"><strong class="req-handle">[PP-2]</strong> Support the association of authoring and rights metadata
+          with alternative content resources, including copyright and usage information. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="PP-3"><strong class="req-handle">[PP-3]</strong> Support the simple replacement of alternative content resources
           even after publishing. This is again dependent on authoring practice
           - if the content creator delivers a final media file that contains
           related accessibility content inside the media wrapper (for example
           an MP4 file), then it will require an appropriate third-party authoring
           tool to make changes to that file - it cannot be demanded of the browser
-          to do so. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="PP-4"><strong class="req-handle">[PP-4]</strong> Typically, alternative content resources are created by different
+          to do so. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="PP-4"><strong class="req-handle">[PP-4]</strong> Typically, alternative content resources are created by different
           entities to the ones that create the media content. They may even be
           in different countries and not be allowed to re-publish the other one's
           content. It is important to be able to host these resources separately,
           associate them together through the web page author, and eventually
-          play them back synchronously to the user. </h4>
-				</section>
+          play them back synchronously to the user. </div>
+				</div>
 			</section>
 			<section>
 				<h3> Discovery and activation/deactivation of available alternative content
@@ -1264,54 +1269,54 @@ var respecConfig = {
       should adhere to the following UAAG guidance: </p>
 				<p>The user agent can facilitate the discovery of alternative content by
         following these criteria: </p>
-				<section class="indent">
-					<h4 id="DAC-1"><strong class="req-handle">[DAC-1]</strong> The user has the ability to have indicators rendered along
+				<div class="indent">
+					<div class='requirement' id="DAC-1"><strong class="req-handle">[DAC-1]</strong> The user has the ability to have indicators rendered along
           with rendered elements that have alternative content (e.g., visual
           icons rendered in proximity of content which has short text alternatives,
           long descriptions, or captions). In cases where the alternative content
           has different dimensions than the original content, the user has the
           option to specify how the layout/reflow of the document should be handled.
-          (UAAG 2.0 1.8.7). </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DAC-2"><strong class="req-handle">[DAC-2]</strong> The user has a global option to specify which types of alternative
+          (UAAG 2.0 1.8.7). </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DAC-2"><strong class="req-handle">[DAC-2]</strong> The user has a global option to specify which types of alternative
           content by default and, in cases where the alternative content has
           different dimensions than the original content, how the layout/reflow
-          of the document should be handled. (UAAG 2.0 1.8.7). </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DAC-3"><strong class="req-handle">[DAC-3]</strong> The user can browse the alternatives and switch between
-          them. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DAC-4"><strong class="req-handle">[DAC-4]</strong> Synchronized alternatives for time-based media (e.g., captions,
+          of the document should be handled. (UAAG 2.0 1.8.7). </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DAC-3"><strong class="req-handle">[DAC-3]</strong> The user can browse the alternatives and switch between
+          them. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DAC-4"><strong class="req-handle">[DAC-4]</strong> Synchronized alternatives for time-based media (e.g., captions,
           descriptions, sign language) can be rendered at the same time as their
-          associated audio tracks and visual tracks (UAAG 2.0 2.11.4). </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DAC-5"><strong class="req-handle">[DAC-5]</strong> Non-synchronized alternatives (e.g., short text alternatives,
+          associated audio tracks and visual tracks (UAAG 2.0 2.11.4). </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DAC-5"><strong class="req-handle">[DAC-5]</strong> Non-synchronized alternatives (e.g., short text alternatives,
           long descriptions) can be rendered as replacements for the original
-          rendered content (UAAG 2.0 1.1.3). </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DAC-6"><strong class="req-handle">[DAC-6]</strong> Provide the user with the global option to configure a cascade
+          rendered content (UAAG 2.0 1.1.3). </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DAC-6"><strong class="req-handle">[DAC-6]</strong> Provide the user with the global option to configure a cascade
           of types of alternatives to render by default, in case a preferred
-          alternative content type is unavailable (UAAG 2.0 1.1.4). </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DAC-7"><strong class="req-handle">[DAC-7]</strong> During time-based media playback, the user can determine
+          alternative content type is unavailable (UAAG 2.0 1.1.4). </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DAC-7"><strong class="req-handle">[DAC-7]</strong> During time-based media playback, the user can determine
           which tracks are available and select or deselect tracks. These selections
-          may override global default settings for captions, descriptions, etc. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DAC-8"><strong class="req-handle">[DAC-8]</strong> Provide the user with the option to load time-based media
+          may override global default settings for captions, descriptions, etc. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DAC-8"><strong class="req-handle">[DAC-8]</strong> Provide the user with the option to load time-based media
           content such that the first frame is displayed (if video), but the
-          content is not played until explicit user request. (UAAG 2.0 2.11.2) </h4>
-				</section>
-				<section class="indent">
-					<h4 id="DAC-9"><strong class="req-handle">[DAC-9]</strong> Provide the user with the option to record alternative content
-                    along with the primary content on devices where recording is available. </h4>
-                    <div class="note"
+          content is not played until explicit user request. (UAAG 2.0 2.11.2) </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="DAC-9"><strong class="req-handle">[DAC-9]</strong> Provide the user with the option to record alternative content
+                    along with the primary content on devices where recording is available. </div>
+                    <div class="note">
 					<p>This feature can be user configurable to allow maximum flexibility in trading off the
                     anticipated future need for the description against the amount of extra data storage required. A flexible
                     solution giving maximum control to the user would be to provide a global setting with the following
@@ -1324,7 +1329,7 @@ var respecConfig = {
                         <li>Never record the alternative content.</li>
                     </ul>
                     </div>
-				</section>
+				</div>
 			</section>
 			<section>
 				<h3> Requirements on making properties available to the accessibility interface </h3>
@@ -1340,20 +1345,20 @@ var respecConfig = {
       are self-contained boxes, should ensure the physical design does not block
       access, and should make accessibility controls, such as the closed-caption
       toggle, as prominent as the volume or channel controls. </p>
-				<section class="indent">
-					<h4 id="API-1"><strong class="req-handle">[API-1]</strong> The existence of alternative-content tracks for a media
-          resource must be exposed to the user agent. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="API-2"><strong class="req-handle">[API-2]</strong> Since authors will need access to the alternative content
+				<div class="indent">
+					<div class='requirement' id="API-1"><strong class="req-handle">[API-1]</strong> The existence of alternative-content tracks for a media
+          resource must be exposed to the user agent. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="API-2"><strong class="req-handle">[API-2]</strong> Since authors will need access to the alternative content
           tracks, the structure needs to be exposed to authors as well, which
-          requires a dynamic interface. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="API-3"><strong class="req-handle">[API-3]</strong> Accessibility APIs need to gain access to alternative content
+          requires a dynamic interface. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="API-3"><strong class="req-handle">[API-3]</strong> Accessibility APIs need to gain access to alternative content
           tracks no matter whether those content tracks come from within a resource
-          or are combined through markup on the page. </h4>
-				</section>
+          or are combined through markup on the page. </div>
+				</div>
 			</section>
 			<section>
 				<h3> Requirements on the use of the viewport </h3>
@@ -1370,10 +1375,10 @@ var respecConfig = {
       cause viewers to miss information. The use of this area for things such
       as transport controls, while appealing aesthetically, may lead to accessibility
       conflicts. </p>
-				<section class="indent">
-					<h4 id="VP-1"><strong class="req-handle">[VP-1]</strong> It must be possible to deal with three different
+				<div class="indent">
+					<div class='requirement' id="VP-1"><strong class="req-handle">[VP-1]</strong> It must be possible to deal with three different
           cases for the relation between the viewport size, the position of media
-          and of alternative content:</h4>
+          and of alternative content:</div>
 					<ol class="list-in-req">
 						<li>the alternative content's extent is specified in relation
               to the media viewport (e.g., picture-in-picture video, lower-third
@@ -1395,13 +1400,13 @@ var respecConfig = {
         or provide a position hint in relation to the media. On small devices
         where the video takes up the full viewport, only limited rendering choices
         may be possible, such that the UA may need to override author preferences. </p>
-				</section>
-				<section class="indent">
-					<h4 id="VP-2"><strong class="req-handle">[VP-2]</strong> The user can change the following characteristics
+				</div>
+				<div class="indent">
+					<div class='requirement' id="VP-2"><strong class="req-handle">[VP-2]</strong> The user can change the following characteristics
           of visually rendered text content, overriding those specified by the
           author or user-agent defaults (UAAG 2.0 1.4.1). (Note: this should
           include captions and any text rendered in relation to media elements,
-          so as to be able to magnify and simplify rendered text):</h4>
+          so as to be able to magnify and simplify rendered text):</div>
 					<ol class="list-in-req">
 						<li>text scale (i.e., the general size of text), </li>
 						<li>font family, and </li>
@@ -1410,36 +1415,36 @@ var respecConfig = {
 					<p class="note">This should be achievable through UA configuration or even through
         something like a <a href="http://www.greasespot.net/">greasemonkey script</a> or <a href="http://www.mozilla.org/unix/customizing.html#usercss">user
         CSS</a> which can override styles dynamically in the browser. </p>
-				</section>
-				<section class="indent">
-					<h4 id="VP-3"><strong class="req-handle">[VP-3]</strong> Provide the user with the ability to adjust
+				</div>
+				<div class="indent">
+					<div class='requirement' id="VP-3"><strong class="req-handle">[VP-3]</strong> Provide the user with the ability to adjust
           the size of the time-based media up to the full height or width of
           the containing viewport, with the ability to preserve aspect ratio
           and to adjust the size of the playback viewport to avoid cropping,
           within the scaling limitations imposed by the media itself. (UAAG 2.0
-          1.8.9) </h4>
+          1.8.9) </div>
 					<p class="note">This can be achieved by simply zooming into the web page, which
       will automatically rescale the layout and reflow the content. </p>
-				</section>
-				<section class="indent">
-					<h4 id="VP-4"><strong class="req-handle">[VP-4]</strong> Provide the user with the ability to control
+				</div>
+				<div class="indent">
+					<div class='requirement' id="VP-4"><strong class="req-handle">[VP-4]</strong> Provide the user with the ability to control
           the contrast and brightness of the content within the playback viewport.
-          (UAAG 2.0 2.11.8) </h4>
+          (UAAG 2.0 2.11.8) </div>
 					<p class="note">This is a user-agent device requirement and should already be
         addressed in the UAAG. In live content, it may even be possible to adjust
         camera settings to achieve this requirement. It is also a   &quot;SHOULD&quot; level
         requirement, since it does not account for limitations of various devices. </p>
-				</section>
-				<section class="indent">
-					<h4 id="VP-5"><strong class="req-handle">[VP-5]</strong> Captions and subtitles traditionally occupy
+				</div>
+				<div class="indent">
+					<div class='requirement' id="VP-5"><strong class="req-handle">[VP-5]</strong> Captions and subtitles traditionally occupy
           the lower third of the video, where controls are also usually
           rendered. The user agent must avoiding overlapping of overlay content
           and controls on media resources. This must also happen if, for example,
-          the controls are only visible on demand. </h4>
+          the controls are only visible on demand. </div>
 					<p class="note">If there are several types of overlapping overlays, the controls
         should stay on the bottom edge of the viewport and the others should
         be moved above this area, all stacked above each other. </p>
-				</section>
+				</div>
 			</section>
 			<section>
 				<h3>Requirements on secondary screens and other devices</h3>
@@ -1453,37 +1458,37 @@ var respecConfig = {
       made, and a detailed response was provided. The response requires review
       and integration into this document, but can be found today in the <a href="http://lists.w3.org/Archives/Public/public-html-a11y/2010Jul/0108.html">22 July 2010 message on this topic</a>). </p>
 				<p>Systems supporting multiple devices for accessibility must: </p>
-				<section class="indent">
-					<h4 id="MD-1"><strong class="req-handle">[MD-1]</strong> Support a platform-accessibility architecture relevant to
-          the operating environment. (UAAG 2.0 4.1.1) </h4>
-				</section>
-				<section class="indent">
-					<h4 id="MD-2"><strong class="req-handle">[MD-2]</strong> Ensure accessibility of all user-interface components including
+				<div class="indent">
+					<div class='requirement' id="MD-1"><strong class="req-handle">[MD-1]</strong> Support a platform-accessibility architecture relevant to
+          the operating environment. (UAAG 2.0 4.1.1) </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="MD-2"><strong class="req-handle">[MD-2]</strong> Ensure accessibility of all user-interface components including
           the user interface, rendered content, and alternative content; make
           available the name, role, state, value, and description via a platform-accessibility
-          architecture. (UAAG 2.0 4.1.2) </h4>
-				</section>
-				<section class="indent">
-					<h4 id="MD-3"><strong class="req-handle">[MD-3]</strong> If a feature is not supported by the accessibility architecture(s),
+          architecture. (UAAG 2.0 4.1.2) </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="MD-3"><strong class="req-handle">[MD-3]</strong> If a feature is not supported by the accessibility architecture(s),
           provide an equivalent feature that does support the accessibility architecture(s).
           Document the equivalent feature in the conformance claim. (UAAG 2.0
-          4.1.3) </h4>
-				</section>
-				<section class="indent">
-					<h4 id="MD-4"><strong class="req-handle">[MD-4]</strong> If the user agent implements one or more DOMs, they must
+          4.1.3) </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="MD-4"><strong class="req-handle">[MD-4]</strong> If the user agent implements one or more DOMs, they must
           be made programmatically available to assistive technologies. (UAAG
-          2.0 4.1.4) This assumes the video element will write to the DOM. </h4>
-				</section>
-				<section class="indent">
-					<h4 id="MD-5"><strong class="req-handle">[MD-5]</strong> If the user can modify the state or value of a piece of content
+          2.0 4.1.4) This assumes the video element will write to the DOM. </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="MD-5"><strong class="req-handle">[MD-5]</strong> If the user can modify the state or value of a piece of content
           through the user interface (e.g., by checking a box or editing a text
           area), the same degree of write access is available programmatically
-          (UAAG 2.0 4.1.5). </h4>
-				</section>
-				<section class="indent">
-					<h4 id="MD-6"><strong class="req-handle">[MD-6]</strong> If any of the following properties are supported by the accessibility-platform
+          (UAAG 2.0 4.1.5). </div>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="MD-6"><strong class="req-handle">[MD-6]</strong> If any of the following properties are supported by the accessibility-platform
           architecture, make the properties available to the accessibility-platform
-          architecture (UAAG 2.0 4.1.6):</h4>
+          architecture (UAAG 2.0 4.1.6):</div>
 					<ol class="list-in-req">
 						<li>the bounding dimensions and coordinates of rendered graphical
               objects; </li>
@@ -1493,18 +1498,18 @@ var respecConfig = {
 						<li>text background color; </li>
 						<li>change state/value notifications. </li>
 					</ol>
-				</section>
-				<section class="indent">
-					<h4 id="MD-7"><strong class="req-handle">[MD-7]</strong> Ensure that programmatic exchanges between APIs proceed at
-          a rate such that users do not perceive a delay. (UAAG 2.0 4.1.7). </h4>
-				</section>
+				</div>
+				<div class="indent">
+					<div class='requirement' id="MD-7"><strong class="req-handle">[MD-7]</strong> Ensure that programmatic exchanges between APIs proceed at
+          a rate such that users do not perceive a delay. (UAAG 2.0 4.1.7). </div>
+				</div>
 			</section>
 		</section>
 		<section class="appendix">
 			<h2>Acknowledgements</h2>
 			<p>The following people contributed to the development of this document.</p>
 			<section id="ack_group">
-				<h4>Participants in the PFWG at the time of publication</h4>
+				<div class='requirement'>Participants in the PFWG at the time of publication</div>
 				<ol>
 					<li>David Bolter (Mozilla) </li>
 					<li>Sally Cain (Royal National Institute of Blind People)</li>


### PR DESCRIPTION
These changes remove the section numbers from our requirements and allow us to manage the formatting of the requirements with a class instead of relying upon the h4 style.
